### PR TITLE
switch to ctxR github for bug fix

### DIFF
--- a/.github/workflows/bookdown.yml
+++ b/.github/workflows/bookdown.yml
@@ -40,6 +40,9 @@ jobs:
           # Pin factoextra
           Rscript -e 'remotes::install_version("factoextra", version = "1.0.7", repos = "https://cran.rstudio.com")'
 
+          # Install ctxR from GitHub
+          Rscript -e 'remotes::install_github("USEPA/ctxR")'
+
           # Now install remaining CRAN deps from DESCRIPTION
           Rscript -e 'remotes::install_deps(dependencies = TRUE, upgrade = "never")'
 

--- a/.github/workflows/bookdown.yml
+++ b/.github/workflows/bookdown.yml
@@ -28,6 +28,8 @@ jobs:
           brew install pandoc
 
       - name: Install CRAN & Bioconductor packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           Rscript -e 'if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")'
 
@@ -41,7 +43,7 @@ jobs:
           Rscript -e 'remotes::install_version("factoextra", version = "1.0.7", repos = "https://cran.rstudio.com")'
 
           # Install ctxR from GitHub
-          Rscript -e 'remotes::install_github("USEPA/ctxR")'
+          Rscript -e 'remotes::install_github("USEPA/ctxR", auth_token = Sys.getenv("GITHUB_TOKEN"))'
 
           # Now install remaining CRAN deps from DESCRIPTION
           Rscript -e 'remotes::install_deps(dependencies = TRUE, upgrade = "never")'

--- a/.github/workflows/test_bookdown.yml
+++ b/.github/workflows/test_bookdown.yml
@@ -31,6 +31,8 @@ jobs:
           brew install pandoc
 
       - name: Install CRAN & Bioconductor packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           Rscript -e 'if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")'
 
@@ -44,7 +46,7 @@ jobs:
           Rscript -e 'remotes::install_version("factoextra", version = "1.0.7", repos = "https://cran.rstudio.com")'
 
           # Install ctxR from GitHub
-          Rscript -e 'remotes::install_github("USEPA/ctxR")'
+          Rscript -e 'remotes::install_github("USEPA/ctxR", auth_token = Sys.getenv("GITHUB_TOKEN"))'
 
           # Now install remaining CRAN deps from DESCRIPTION
           Rscript -e 'remotes::install_deps(dependencies = TRUE, upgrade = "never")'

--- a/.github/workflows/test_bookdown.yml
+++ b/.github/workflows/test_bookdown.yml
@@ -43,6 +43,9 @@ jobs:
           # Pin factoextra
           Rscript -e 'remotes::install_version("factoextra", version = "1.0.7", repos = "https://cran.rstudio.com")'
 
+          # Install ctxR from GitHub
+          Rscript -e 'remotes::install_github("USEPA/ctxR")'
+
           # Now install remaining CRAN deps from DESCRIPTION
           Rscript -e 'remotes::install_deps(dependencies = TRUE, upgrade = "never")'
 


### PR DESCRIPTION
Closes #10, closes #12, closes #13

The underlying CTX API JSON database changed, causing the reported 
breakage. The fix has been pushed to USEPA/ctxR on GitHub but is not 
yet available on CRAN, so the ctxR dependency has been updated to 
install directly from GitHub.